### PR TITLE
Address npm production config warning

### DIFF
--- a/whatsapp-ai-bot/README.md
+++ b/whatsapp-ai-bot/README.md
@@ -28,6 +28,8 @@ Un bot WhatsApp intelligent alimenté par OpenAI et intégré via Twilio. Le bot
 git clone <votre-repo>
 cd whatsapp-ai-bot
 npm install
+# Pour un environnement de production, utilisez :
+# npm install --omit=dev
 ```
 
 ### 2. Configuration des variables d'environnement

--- a/whatsapp-ai-bot/package.json
+++ b/whatsapp-ai-bot/package.json
@@ -7,6 +7,7 @@
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
+    "install:prod": "npm install --omit=dev",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "test": "jest",


### PR DESCRIPTION
Add `install:prod` script and update README to use `--omit=dev` for production installations to resolve npm warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8f81b93-734f-4952-8443-f29d27cb7741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8f81b93-734f-4952-8443-f29d27cb7741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

