### PR TITLE
Require user confirmation for commands

### DIFF
--- a/whatsapp-ai-bot/src/services/openai.ts
+++ b/whatsapp-ai-bot/src/services/openai.ts
@@ -22,13 +22,13 @@ Validation de fin :
 
 Récapitulatif :
 - Chantier :
-- (Matériau tel que demandé par l’ouvrier)
+- (Matériau tel que demandé par l'ouvrier)
 - Quantité + unité :
 - Besoin pour (date/heure) :
 
-« Peux-tu confirmer ce récapitulatif ? »
-- Si c’est confirmé : « Commande prête à être transmise. »
-- Sinon : demande les corrections nécessaires.
+« Pour confirmer cette commande, réponds simplement "ok" (uniquement ce mot) »
+- Si l'utilisateur répond exactement "ok" : « Commande prête à être transmise. »
+- Si l'utilisateur répond autre chose que "ok" : demande les corrections nécessaires ou rappelle qu'il faut répondre exactement "ok" pour confirmer.
 
 Règles de clarification :
 - Si l’unité est absente/inadaptée, demande l’unité attendue.

--- a/whatsapp-ai-bot/src/utils/orderParser.ts
+++ b/whatsapp-ai-bot/src/utils/orderParser.ts
@@ -124,15 +124,11 @@ export function parseOrderFromResponse(response: string, userMessage?: string, c
     }
 
     // Vérifier si la commande est confirmée
-    // Chercher la confirmation dans la réponse de l'IA ET dans le message utilisateur
-    const confirmationInResponse = /commande prête à être transmise/i.test(cleanResponse) ||
-                                  /commande confirmée/i.test(cleanResponse) ||
-                                  /parfait|ok|c'est bon|validé|confirmé/i.test(cleanResponse);
-    
+    // Seule la réponse exacte "ok" de l'utilisateur confirme la commande
     const confirmationInUserMessage = userMessage ? 
-      (/oui|yes|confirm|je confirme|c'est bon|ok|parfait|validé|d'accord/i.test(userMessage.trim())) : false;
+      (/^ok$/i.test(userMessage.trim())) : false;
     
-    result.is_confirmed = confirmationInResponse || confirmationInUserMessage;
+    result.is_confirmed = confirmationInUserMessage;
 
     // Vérifier si toutes les informations sont présentes
     result.is_complete = !!(result.chantier && result.materiau && result.quantite && 


### PR DESCRIPTION
Enforce strict command confirmation by requiring the user to explicitly respond with "ok".

The previous implementation accepted various affirmative phrases, leading to potential ambiguity. This change enhances security and clarity by making "ok" the sole valid confirmation, both in the system prompt and the order parsing logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-443e26e8-8d40-4250-b153-8294269e3df8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-443e26e8-8d40-4250-b153-8294269e3df8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

