### PR TITLE
Fix supabase policy creation syntax error

### DIFF
--- a/whatsapp-ai-bot/supabase_setup.sql
+++ b/whatsapp-ai-bot/supabase_setup.sql
@@ -90,8 +90,15 @@ BEGIN
   
   -- Créer une politique permettant toutes les opérations
   -- (vous pouvez restreindre selon vos besoins de sécurité)
+  -- Supprimer la politique si elle existe déjà
+  EXECUTE format('DROP POLICY IF EXISTS %I ON %I',
+    'policy_' || table_name || '_all_operations',
+    table_name
+  );
+  
+  -- Créer la nouvelle politique
   EXECUTE format('
-    CREATE POLICY IF NOT EXISTS %I 
+    CREATE POLICY %I 
     ON %I FOR ALL 
     USING (true)',
     'policy_' || table_name || '_all_operations',
@@ -124,7 +131,11 @@ CREATE INDEX IF NOT EXISTS idx_brikstik_logs_table ON brikstik_logs (table_name)
 -- Activer RLS et créer des politiques pour la table de logs
 ALTER TABLE brikstik_logs ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY IF NOT EXISTS "Enable all operations for all users on logs" 
+-- Supprimer la politique si elle existe déjà
+DROP POLICY IF EXISTS "Enable all operations for all users on logs" ON brikstik_logs;
+
+-- Créer la politique
+CREATE POLICY "Enable all operations for all users on logs" 
 ON brikstik_logs FOR ALL 
 USING (true);
 


### PR DESCRIPTION
Replace unsupported `CREATE POLICY IF NOT EXISTS` with `DROP POLICY IF EXISTS` followed by `CREATE POLICY` to resolve SQL syntax errors in Supabase.

The original `CREATE POLICY IF NOT EXISTS` syntax is not supported by PostgreSQL, causing a `syntax error at or near "NOT"`. The updated approach explicitly drops the policy if it exists before creating it, ensuring idempotency and compatibility with PostgreSQL/Supabase.

---
<a href="https://cursor.com/background-agent?bcId=bc-4cc70ec6-3442-4d20-8905-a19b7c3bf409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4cc70ec6-3442-4d20-8905-a19b7c3bf409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

